### PR TITLE
Add 'me' to tenuous emoji stopwords 🇺🇸

### DIFF
--- a/src/stopwords.js
+++ b/src/stopwords.js
@@ -48,8 +48,8 @@ const additionalStopwords = [
 	'so',
 	'up',
 	'us',
-	'you',
-	'what'
+	'what',
+	'you'
 ];
 
 module.exports = luceneStopwords.concat(additionalStopwords)

--- a/src/stopwords.js
+++ b/src/stopwords.js
@@ -44,6 +44,7 @@ const additionalStopwords = [
 	'have',
 	'here',
 	'like',
+	'me',
 	'so',
 	'up',
 	'us',


### PR DESCRIPTION
> I've just seen this in the middle of Brum. It made me snort coffee out of my nose.

Sensible emoji response: ☕
Actual emoji response: 🇺🇸

The word "me" seems to result in a `flag-us`. Without this, a coffee emoji will appear.

