### PR TITLE
Upgrade Node runtime

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -11,7 +11,7 @@ provider:
   name: aws
   region: eu-west-1
   stage: dev
-  runtime: nodejs4.3
+  runtime: nodejs10.x
   environment:
     CLIENT_ID: ${file(local.yml):${opt:stage, self:provider.stage}.slack.clientId}
     CLIENT_SECRET: ${file(local.yml):${opt:stage, self:provider.stage}.slack.clientSecret}


### PR DESCRIPTION
The Node 4.3 runtime is no longer available, so switch to Node 10.x runtime.

I have sucessfully deployed to AWS, added into a Slack workspace, and held meaningful conversations with Emojibot.