### PR TITLE
Add 'its' to tenuous emoji stopwords 🇮🇹

### DIFF
--- a/src/stopwords.js
+++ b/src/stopwords.js
@@ -43,6 +43,7 @@ const additionalStopwords = [
 	'has',
 	'have',
 	'here',
+	'its',
 	'like',
 	'me',
 	'so',


### PR DESCRIPTION
Stops emojibot reacting with 🇮🇹 when messages with 'its' are posted.